### PR TITLE
fix(diagnostic): initialise ESS_warn before if(diagnostic) block

### DIFF
--- a/R/wrap_bart.R
+++ b/R/wrap_bart.R
@@ -575,11 +575,11 @@ subart <- function(x_train,
           }
 
           # Calculate the ESS for all parameters throw a warning if any of them is smaller than half of the MCMC samples
+          ESS_warn <- FALSE
           if(diagnostic){
 
                diagnostic_bool = FALSE
                ESS_val <- matrix(NA, nrow = nrow(Sigma_post), ncol = ncol(Sigma_post))
-               ESS_warn <- FALSE
                for(i in 1:nrow(Sigma_post)){
                     # ESS_val[i,i] <- ESS(x = Sigma_post[i,i,]) # For classification there's no sample
                     j = i
@@ -659,11 +659,11 @@ subart <- function(x_train,
           }
 
           # Calculate the ESS for all parameters throw a warning if any of them is smaller than half of the MCMC samples
+          ESS_warn <- FALSE
           if(diagnostic){
 
                diagnostic_bool = FALSE
                ESS_val <- matrix(NA, nrow = nrow(Sigma_post), ncol = ncol(Sigma_post))
-               ESS_warn <- FALSE
                for(i in 1:nrow(Sigma_post)){
                     ESS_val[i,i] <- ESS(x = sqrt(Sigma_post[i,i,]))
                     j = i


### PR DESCRIPTION
When diagnostic=FALSE, ESS_warn was never assigned, causing:
  Error: object 'ESS_warn' not found
on the unconditional if(ESS_warn) check that follows.

Fix: hoist ESS_warn <- FALSE to before the if(diagnostic) block in both the classification and regression branches of wrap_bart.R.